### PR TITLE
Fix Spanish translation

### DIFF
--- a/es_ar.json
+++ b/es_ar.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",

--- a/es_cl.json
+++ b/es_cl.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",

--- a/es_ec.json
+++ b/es_ec.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",

--- a/es_es.json
+++ b/es_es.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",

--- a/es_mx.json
+++ b/es_mx.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",

--- a/es_uy.json
+++ b/es_uy.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",

--- a/es_ve.json
+++ b/es_ve.json
@@ -11,7 +11,7 @@
     "cannotUnregister": "§c¡No puedes dar de baja esta cuenta!",
     "notAuthenticated": "§c¡No estás autenticado!\n§6Intenta con /login o /register.",
     "alreadyAuthenticated": "§6Ahora estás autenticado.",
-    "successfullyAuthenticated": "§aNo estás autenticado.",
+    "successfullyAuthenticated": "§aTe has autenticado.",
     "successfulLogout": "§aCerraste sesión correctamente.",
     "timeExpired": "§cEl tiempo de autenticación ha expirado.",
     "registerRequired": "§6Escribe /register \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",


### PR DESCRIPTION
I inadvertently wrote the opposite (`you're not authenticated` instead of `You are now authenticated.`)