### PR TITLE
update to forge 35.1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ minecraft {
 
     //mappings channel: 'stable', version: "yarn-${minecraft_version}"
     //mappings channel: 'snapshot', version: "${new Date().format("yyyyMMdd")}-yarn-${minecraft_version}"
-    mappings channel: 'snapshot', version: "20201012-yarn-${minecraft_version}"
+    mappings channel: 'snapshot', version: "${mc_mappings}-yarn-${minecraft_version_mappings}"
 
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.daemon=false
 
 
-minecraft_version=1.16.3
+minecraft_version=1.16.4
+minecraft_version_mappings=1.16.3
 # Forge stuff
-mc_mappings = 20200725
-forge_version = 34.1.0
+mc_mappings = 20201012
+forge_version = 35.1.4
 
 # Mod Properties
-mod_version = 1.6.1.1
+mod_version = 1.6.1.2
 maven_group = org.samo_lego
 archives_base_name = simpleauth
 


### PR DESCRIPTION
Hi, I looking for auth mod for 1.16.4, and I found you mod for 1.16.3. I checked latest [Forge MDK](http://files.minecraftforge.net/maven/net/minecraftforge/forge/index_1.16.4.html), and I noticed that forge for 1.16.4 is using mapping for 1.16.3. I updated gradle build, and mod is building correctly for 1.16.4. We are using it currently on server. Maybe you are interested in this change?
BR